### PR TITLE
Fix dynamic job naming for migration job

### DIFF
--- a/k8s/migration-job.yaml
+++ b/k8s/migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: db-migration
+  name: db-migration-{{random}}
   annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation


### PR DESCRIPTION
## Summary
This PR fixes the migration job naming to use dynamic names so that each sync can create a new job successfully.

## Problem
The migration job had a static name `db-migration`, which caused conflicts when trying to create new jobs during sync operations. Since Kubernetes Jobs with the same name can't be recreated until the old one is deleted, the sync was getting stuck.

## Solution
- **Dynamic Job Naming**: Changed job name from `db-migration` to `db-migration-{{random}}`
- **Unique Names**: Each sync will create a job with a unique random suffix
- **BeforeHookCreation Policy**: Ensures only one job exists at a time by deleting old jobs before creating new ones
- **PreSync Hook**: Will now run successfully on each sync operation

## Changes
- Modified `k8s/migration-job.yaml` to use dynamic naming
- Job name now uses `{{random}}` suffix for uniqueness
- Maintains all existing functionality and logging

## Expected Results
- ✅ Each sync will create a new migration job with unique name
- ✅ PreSync hook will run successfully
- ✅ Only one job will exist at a time
- ✅ No more conflicts with existing jobs
- ✅ Migration job will complete successfully

This fix ensures that the ArgoCD sync process can proceed without being blocked by existing job names.