### PR TITLE
Fix job naming to use generateName for unique job names

### DIFF
--- a/k8s/migration-job.yaml
+++ b/k8s/migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: db-migration-{{random}}
+  generateName: db-migration-
   annotations:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation


### PR DESCRIPTION
## Summary
This PR fixes the migration job naming to use `generateName` instead of `name`, which is the proper Kubernetes way to create jobs with unique names.

## Problem
The previous approach using `{{random}}` or `{{timestamp}}` syntax was not being processed by ArgoCD and was causing validation errors. The static name approach was causing conflicts when trying to create new jobs.

## Solution
- **Use `generateName`**: Changed from `name: db-migration` to `generateName: db-migration-`
- **Automatic Suffix**: Kubernetes will automatically append a random suffix (e.g., `db-migration-abc123`)
- **Unique Names**: Each sync will create a job with a unique name
- **No Conflicts**: Prevents conflicts with existing jobs
- **Proper Cleanup**: `BeforeHookCreation` policy will clean up old jobs

## Changes
- Modified `k8s/migration-job.yaml` to use `generateName: db-migration-`
- This is the standard Kubernetes pattern for dynamic job naming
- Maintains all existing functionality and logging

## Expected Results
- ✅ Each sync will create a new migration job with unique name
- ✅ PreSync hook will run successfully
- ✅ No more validation errors
- ✅ Proper Kubernetes resource naming
- ✅ Migration job will complete successfully

This fix uses the proper Kubernetes pattern for creating jobs with unique names.