### PR TITLE
Fix resource limits to resolve CrashLoopBackOff issue

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,11 +19,11 @@ spec:
             - containerPort: 80
           resources:
             requests:
-              memory: "1Mi"
-              cpu: "1m"
+              memory: "64Mi"
+              cpu: "50m"
             limits:
-              memory: "2Mi"
-              cpu: "2m"
+              memory: "128Mi"
+              cpu: "100m"
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## 🚨 Critical Fix: Resource Limits

### Problem
The hello-world deployment was experiencing `CrashLoopBackOff` due to insufficient resource allocation:
- Memory limit: 2Mi (too low for nginx)
- CPU limit: 2m (too restrictive)

### Solution
Increased resource limits to reasonable values for nginx:
- **Memory request**: 1Mi → 64Mi
- **Memory limit**: 2Mi → 128Mi  
- **CPU request**: 1m → 50m
- **CPU limit**: 2m → 100m

### Impact
- ✅ Resolves container crash issues
- ✅ Allows nginx to start properly
- ✅ Fixes deployment rollout stuck in progress
- ✅ Improves application stability

### Testing
The fix addresses the specific error seen in ArgoCD:
- Pod status: `CrashLoopBackOff` → Should become `Running`
- Health status: `Degraded` → Should become `Healthy`
- Deployment status: `Progressing` → Should become `Healthy`

This is a critical fix that should be merged immediately to restore application functionality.