### PR TITLE
Fix crasher deployment OOM issue by increasing memory limits

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -58,8 +58,8 @@ spec:
               done
           resources:
             requests:
-              memory: "1Mi"
-              cpu: "1m"
+              memory: "32Mi"
+              cpu: "10m"
             limits:
-              memory: "2Mi"
-              cpu: "2m"
+              memory: "64Mi"
+              cpu: "50m"


### PR DESCRIPTION
## Problem
The crasher deployment was failing with CrashLoopBackOff due to OOM (Out of Memory) kills. The container was being terminated with the error:
```
container init was OOM-killed (memory limit too low?)
```

## Root Cause
The crasher container had extremely low resource limits:
- Memory requests: 1Mi
- Memory limits: 2Mi
- CPU requests: 1m
- CPU limits: 2m

These limits were insufficient for the Alpine container to start up successfully.

## Solution
Increased resource limits to reasonable values:
- Memory requests: 32Mi (was 1Mi)
- Memory limits: 64Mi (was 2Mi)
- CPU requests: 10m (was 1m)
- CPU limits: 50m (was 2m)

## Testing
- ✅ Application health changed from Degraded to Healthy
- ✅ Crasher deployment health changed from Degraded to Healthy
- ✅ Crasher pod status changed from CrashLoopBackOff to Running
- ✅ All resources are now Synced

## Impact
This fix resolves the application's degraded health status and ensures all components are running properly.