### PR TITLE
Fix crasher deployment resource limits

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -58,8 +58,8 @@ spec:
               done
           resources:
             requests:
-              memory: "1Mi"
-              cpu: "1m"
+              memory: "16Mi"
+              cpu: "10m"
             limits:
-              memory: "2Mi"
-              cpu: "2m"
+              memory: "32Mi"
+              cpu: "50m"


### PR DESCRIPTION
## Problem
The `crasher` deployment was failing with "ProgressDeadlineExceeded" error due to insufficient resource limits.

## Root Cause
The resource limits were too restrictive:
- CPU limit: 2m (0.002 CPU cores)
- Memory limit: 2Mi (2 megabytes)

This caused the container to be killed when trying to run the shell script with echo commands and sleep loop.

## Solution
Increased resource limits to allow the container to run properly:
- CPU limits: 2m → 50m (25x increase)
- Memory limits: 2Mi → 32Mi (16x increase)
- CPU requests: 1m → 10m
- Memory requests: 1Mi → 16Mi

## Expected Result
- Crasher deployment should start successfully
- Application health should change from "Degraded" to "Healthy"
- No more "ProgressDeadlineExceeded" errors